### PR TITLE
Fix day-of-week for changelog entry 0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systune (0.5.13) UNRELEASED; urgency=medium
+
+  * Fix day-of-week for changelog entry 0.3-2.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 22:06:39 +0000
+
 systune (0.5.12) unstable; urgency=medium
 
   * No change, rebuild for source only upload.
@@ -126,7 +132,7 @@ systune (0.3-2) unstable; urgency=low
   * Fixed some typos
   * yada technology
 
- -- Piotr Roszatycki <dexter@debian.org>  Mon,  7 May 1999 01:56:03 +0200
+ -- Piotr Roszatycki <dexter@debian.org>  Fri, 07 May 1999 01:56:03 +0200
 
 systune (0.3-1) unstable; urgency=low
 


### PR DESCRIPTION
Fix day-of-week for changelog entry 0.3-2. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/systune/fff5a8d6-88b3-489b-a563-b6a71824187f.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/fff5a8d6-88b3-489b-a563-b6a71824187f/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/fff5a8d6-88b3-489b-a563-b6a71824187f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/fff5a8d6-88b3-489b-a563-b6a71824187f/diffoscope)).
