### PR TITLE
Move orphaned package to the QA team.Please move the repository from https://github.com/sudipm-mukherjee/systune.git to https://salsa.debian.org/debian/systune.git

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+systune (0.5.14) UNRELEASED; urgency=low
+
+  * QA Upload.
+    Move package to QA team.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 05 Jul 2020 11:29:28 -0000
+
 systune (0.5.13) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -1,12 +1,12 @@
 Source: systune
-Maintainer: Sudip Mukherjee <sudipm.mukherjee@gmail.com>
+Maintainer: Debian QA Group <packages@qa.debian.org>
 Section: admin
 Priority: optional
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Build-Depends: debhelper-compat (= 13)
-Vcs-Git: https://github.com/sudipm-mukherjee/systune.git
-Vcs-Browser: https://github.com/sudipm-mukherjee/systune.git
+Vcs-Git: https://salsa.debian.org/debian/systune.git
+Vcs-Browser: https://salsa.debian.org/debian/systune
 
 Package: systune
 Architecture: all


### PR DESCRIPTION
Move orphaned package to the QA team.Please move the repository from https://github.com/sudipm-mukherjee/systune.git to https://salsa.debian.org/debian/systune.git.
If you have the salsa(1) tool installed, run: 

    git clone https://github.com/sudipm-mukherjee/systune.git systune.git
    salsa --group=debian push_repo systune.git

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/orphan).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/orphan.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/orphan/pkg/systune/822c3be6-8cc6-4691-b9ac-fce0df06a730.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Maintainer: [-Sudip Mukherjee <sudipm.mukherjee@gmail.com>-] {+Debian QA Group <packages@qa.debian.org>+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/822c3be6-8cc6-4691-b9ac-fce0df06a730/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/822c3be6-8cc6-4691-b9ac-fce0df06a730/diffoscope)).
